### PR TITLE
Fix: Fix the reference parameter name error

### DIFF
--- a/config/setting.py
+++ b/config/setting.py
@@ -24,7 +24,7 @@ DEFAULT_IMAGE_SIZE = [64, 64]
 
 # model.networks.sr
 SR_IMAGE_TYPE = "RGB"
-SR_IMAGE_CHANNEL = image_type_choices[IMAGE_TYPE]
+SR_IMAGE_CHANNEL = image_type_choices[SR_IMAGE_TYPE]
 
 # Data processing
 # ****** torchvision.transforms.Compose ******


### PR DESCRIPTION
Fix the reference parameter name error. The name is "SR_IMAGE_TYPE" instead of "IMAGE_TYPE"